### PR TITLE
Add required packages to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-yt-dlp
-pillow
-numpy
-requests
+numpy==2.3.3
+pillow==11.3.0
+requests==2.32.5
+yt-dlp==2025.9.26

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+yt-dlp
+pillow
+numpy
+requests


### PR DESCRIPTION
Adds a simple requirements.txt file to allow dependency installation via `pip install -r requirements.txt`. You mentioned a requirements file in the readme, but there isn't one in the repo so I just quickly made one. :)

(also I wrote this on my phone and haven't actually tested it yet but I don't see why it wouldn't work 😅)

Thanks for releasing the script! <3