### PR TITLE
Fix wrong arg to average_blend

### DIFF
--- a/average_thumbnails.py
+++ b/average_thumbnails.py
@@ -397,7 +397,7 @@ boneless chicken""")
 
 
 def generate_blended_thumbnails(args, playlist_folder: Path, thumbnails: list[Image.Image]):
-    if args.median_blend:
+    if args.average_blend:
         print("  ✩ creating average blend...")
         average_blend(thumbnails).save(playlist_folder / 'average_thumbnail.png')
 


### PR DESCRIPTION
The current code for average blend is accidentally looks for args.median_blend. This fixes that
https://github.com/emnerson/youtube-thumbnail-averager/blob/main/average_thumbnails.py#L400
