### PR TITLE
Update yt-dlp

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy==2.3.3
 pillow==11.3.0
 requests==2.32.5
-yt-dlp==2025.9.26
+yt-dlp


### PR DESCRIPTION
yt-dlp got a new update today, so there's really no reason to use the old outdated version anymore
having the package in the requirements.txt by itself installs the latest version by default, you don't have to specify the version